### PR TITLE
Feature/us12 to us17 tasks

### DIFF
--- a/server/migrations/20260521120000-update-tasks-status-add-completion.js
+++ b/server/migrations/20260521120000-update-tasks-status-add-completion.js
@@ -1,0 +1,82 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // 1. Supprimer le défaut AVANT de changer le type
+    //    (sinon PostgreSQL refuse car le défaut référence l'ancien type)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Tasks" ALTER COLUMN status DROP DEFAULT;
+    `);
+
+    // 2. Renommer l'ancien type, créer le nouveau, migrer les données
+    await queryInterface.sequelize.query(`
+      ALTER TYPE "enum_Tasks_status" RENAME TO "enum_Tasks_status_old";
+    `);
+    await queryInterface.sequelize.query(`
+      CREATE TYPE "enum_Tasks_status" AS ENUM('à faire', 'terminée');
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Tasks"
+        ALTER COLUMN status TYPE "enum_Tasks_status"
+        USING CASE
+          WHEN status::text = 'pending'     THEN 'à faire'
+          WHEN status::text = 'in_progress' THEN 'à faire'
+          WHEN status::text = 'done'        THEN 'terminée'
+          ELSE 'à faire'
+        END::"enum_Tasks_status";
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Tasks" ALTER COLUMN status SET DEFAULT 'à faire';
+    `);
+    await queryInterface.sequelize.query(`
+      DROP TYPE "enum_Tasks_status_old";
+    `);
+
+    // 3. Ajouter completedAt — date à laquelle la tâche a été marquée terminée
+    await queryInterface.addColumn('Tasks', 'completedAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+
+    // 4. Ajouter completedBy — UUID de l'utilisateur qui a complété la tâche
+    await queryInterface.addColumn('Tasks', 'completedBy', {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: {
+        model: 'Users',
+        key: 'id',
+      },
+      onDelete: 'SET NULL',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Tasks', 'completedBy');
+    await queryInterface.removeColumn('Tasks', 'completedAt');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Tasks" ALTER COLUMN status DROP DEFAULT;
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TYPE "enum_Tasks_status" RENAME TO "enum_Tasks_status_old";
+    `);
+    await queryInterface.sequelize.query(`
+      CREATE TYPE "enum_Tasks_status" AS ENUM('pending', 'in_progress', 'done');
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Tasks"
+        ALTER COLUMN status TYPE "enum_Tasks_status"
+        USING CASE
+          WHEN status::text = 'à faire'  THEN 'pending'
+          WHEN status::text = 'terminée' THEN 'done'
+          ELSE 'pending'
+        END::"enum_Tasks_status";
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Tasks" ALTER COLUMN status SET DEFAULT 'pending';
+    `);
+    await queryInterface.sequelize.query(`
+      DROP TYPE "enum_Tasks_status_old";
+    `);
+  },
+};

--- a/server/src/controllers/taskController.ts
+++ b/server/src/controllers/taskController.ts
@@ -1,117 +1,302 @@
 import type { Request, Response, NextFunction } from 'express';
+import { Op } from 'sequelize';
 import Task from '../models/Task';
+import Membership from '../models/Membership';
 
-export const getAllTasks = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+const TASK_PUBLIC_ATTRIBUTES = [
+  'id',
+  'title',
+  'description',
+  'status',
+  'assignedTo',
+  'colocationId',
+  'isRecurring',
+  'recurringInterval',
+  'dueDate',
+  'completedAt',
+  'completedBy',
+  'createdAt',
+  'updatedAt',
+] as const;
+
+/**
+ * US-15 / US-16 — GET /api/colocations/:id/tasks
+ * Liste les tâches d'une colocation, avec filtres optionnels status et assignedTo.
+ * Tri par défaut : 'à faire' avant 'terminée', puis dueDate croissante (nulls last).
+ */
+export const getColocationTasks = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
-    const { colocationId } = req.query;
+    const colocationId = (req as any).colocationId as string;
+
+    const where: Record<string, unknown> = { colocationId };
+
+    // US-16 — filtre par statut
+    const statusFilter = req.query['status'] as string | undefined;
+    if (statusFilter) {
+      if (statusFilter !== 'à faire' && statusFilter !== 'terminée') {
+        res.status(400).json({
+          message: "Le filtre status doit valoir 'à faire' ou 'terminée'.",
+        });
+        return;
+      }
+      where['status'] = statusFilter;
+    }
+
+    // US-16 — filtre par membre assigné
+    const assignedToFilter = req.query['assignedTo'] as string | undefined;
+    if (assignedToFilter) {
+      where['assignedTo'] = assignedToFilter;
+    }
+
     const tasks = await Task.findAll({
-      where: colocationId ? { colocationId: String(colocationId) } : {},
-      attributes: ['id', 'title', 'description', 'status', 'assignedTo', 'colocationId', 'isRecurring', 'recurringInterval', 'dueDate', 'createdAt', 'updatedAt'],
+      where,
+      attributes: [...TASK_PUBLIC_ATTRIBUTES],
+      order: [
+        ['status', 'ASC'],   // 'à faire' < 'terminée' alphabétiquement
+        ['dueDate', 'ASC'],
+      ],
     });
+
     res.status(200).json(tasks);
   } catch (error) {
     next(error);
   }
 };
 
-export const getTaskById = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+/**
+ * US-12 — POST /api/colocations/:id/tasks
+ * Crée une tâche dans la colocation. Statut 'à faire' par défaut.
+ */
+export const createTaskInColocation = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
-    const id = req.params['id'] as string;
-    const task = await Task.findByPk(id, {
-      attributes: ['id', 'title', 'description', 'status', 'assignedTo', 'colocationId', 'isRecurring', 'recurringInterval', 'dueDate', 'createdAt', 'updatedAt'],
-    });
-    if (!task) {
-      res.status(404).json({ message: 'Tâche introuvable.' });
-      return;
-    }
-    res.status(200).json(task);
-  } catch (error) {
-    next(error);
-  }
-};
+    const colocationId = (req as any).colocationId as string;
+    const { title, description, dueDate } = req.body;
 
-export const createTask = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    const { title, description, colocationId, assignedTo, isRecurring, recurringInterval, dueDate } = req.body;
-    if (!title || !colocationId) {
-      res.status(400).json({ message: 'Les champs title et colocationId sont obligatoires.' });
+    if (!title || typeof title !== 'string' || title.trim().length === 0) {
+      res.status(400).json({ message: 'Le champ title est obligatoire.' });
       return;
     }
+
+    // dueDate optionnelle, mais si fournie elle doit être dans le futur
+    let parsedDueDate: Date | undefined;
+    if (dueDate !== undefined && dueDate !== null && dueDate !== '') {
+      parsedDueDate = new Date(dueDate);
+      if (Number.isNaN(parsedDueDate.getTime())) {
+        res.status(400).json({ message: "Le champ dueDate n'est pas une date valide." });
+        return;
+      }
+      if (parsedDueDate.getTime() <= Date.now()) {
+        res.status(400).json({ message: 'La date d\'échéance doit être dans le futur.' });
+        return;
+      }
+    }
+
     const task = await Task.create({
-      title,
-      description,
+      title: title.trim(),
+      description: description ?? undefined,
       colocationId,
-      assignedTo,
-      isRecurring: isRecurring ?? false,
-      recurringInterval,
-      dueDate,
-      status: 'pending',
+      dueDate: parsedDueDate,
+      isRecurring: false,
+      status: 'à faire',
     });
+
     res.status(201).json(task);
   } catch (error) {
     next(error);
   }
 };
 
-export const updateTask = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+/**
+ * US-17 (modification) — PATCH /api/tasks/:id
+ * Modifie title, description, dueDate. Aucun autre champ n'est modifiable ici.
+ */
+export const updateTask = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
-    const id = req.params['id'] as string;
-    const task = await Task.findByPk(id);
-    if (!task) {
-      res.status(404).json({ message: 'Tâche introuvable.' });
+    // Task posée par requireColocationMember
+    const task = (req as any).task as Task;
+
+    const { title, description, dueDate } = req.body;
+    // Typage volontairement permissif : null est nécessaire pour effacer
+    // description/dueDate en base, mais le type du modèle ne le déclare pas.
+    const updates: Record<string, unknown> = {};
+
+    if (title !== undefined) {
+      if (typeof title !== 'string' || title.trim().length === 0) {
+        res.status(400).json({ message: 'Le champ title ne peut pas être vide.' });
+        return;
+      }
+      updates['title'] = title.trim();
+    }
+
+    if (description !== undefined) {
+      updates['description'] = description === null ? null : String(description);
+    }
+
+    if (dueDate !== undefined) {
+      if (dueDate === null || dueDate === '') {
+        updates['dueDate'] = null;
+      } else {
+        const parsed = new Date(dueDate);
+        if (Number.isNaN(parsed.getTime())) {
+          res.status(400).json({ message: "Le champ dueDate n'est pas une date valide." });
+          return;
+        }
+        updates['dueDate'] = parsed;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      res.status(400).json({ message: 'Aucun champ valide à modifier.' });
       return;
     }
-    await task.update(req.body);
-    res.status(200).json(task);
+
+    await task.update(updates as any);
+    const refreshed = await Task.findByPk(task.id, {
+      attributes: [...TASK_PUBLIC_ATTRIBUTES],
+    });
+    res.status(200).json(refreshed);
   } catch (error) {
     next(error);
   }
 };
 
-export const assignTask = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+/**
+ * US-13 — PATCH /api/tasks/:id/assign
+ * Assigne (ou désassigne avec null) une tâche à un membre de la même colocation.
+ */
+export const assignTask = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
-    const id = req.params['id'] as string;
-    const task = await Task.findByPk(id);
-    if (!task) {
-      res.status(404).json({ message: 'Tâche introuvable.' });
-      return;
-    }
+    const task = (req as any).task as Task;
     const { assignedTo } = req.body;
+
     if (assignedTo === undefined) {
-      res.status(400).json({ message: 'Le champ assignedTo est obligatoire.' });
+      res.status(400).json({ message: 'Le champ assignedTo est obligatoire (UUID ou null).' });
       return;
     }
+
+    // Désassignation
+    if (assignedTo === null) {
+      await task.update({ assignedTo: undefined });
+      const refreshed = await Task.findByPk(task.id, {
+        attributes: [...TASK_PUBLIC_ATTRIBUTES],
+      });
+      res.status(200).json(refreshed);
+      return;
+    }
+
+    if (typeof assignedTo !== 'string') {
+      res.status(400).json({ message: 'Le champ assignedTo doit être un UUID ou null.' });
+      return;
+    }
+
+    // L'assigné doit être membre de la même colocation que la tâche
+    const targetMembership = await Membership.findOne({
+      where: { userId: assignedTo, colocationId: task.colocationId },
+      attributes: ['id'],
+    });
+    if (!targetMembership) {
+      res.status(400).json({
+        message: "L'utilisateur ciblé n'est pas membre de cette colocation.",
+      });
+      return;
+    }
+
     await task.update({ assignedTo });
-    res.status(200).json(task);
+    const refreshed = await Task.findByPk(task.id, {
+      attributes: [...TASK_PUBLIC_ATTRIBUTES],
+    });
+    res.status(200).json(refreshed);
   } catch (error) {
     next(error);
   }
 };
 
-export const completeTask = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+/**
+ * US-14 — PATCH /api/tasks/:id/complete
+ * Marque la tâche comme 'terminée' (ou la rouvre en 'à faire' si déjà terminée).
+ * Toggle : enregistre / efface completedAt et completedBy en conséquence.
+ * Race condition gérée par UPDATE conditionnel sur le statut courant.
+ */
+export const completeTask = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
-    const id = req.params['id'] as string;
-    const task = await Task.findByPk(id);
-    if (!task) {
-      res.status(404).json({ message: 'Tâche introuvable.' });
-      return;
+    const task = (req as any).task as Task;
+    const userId = (req as any).user.id as string;
+
+    if (task.status === 'à faire') {
+      // Passage à 'terminée' — atomique : on n'écrit que si le statut est encore 'à faire'
+      const [affected] = await Task.update(
+        {
+          status: 'terminée',
+          completedAt: new Date(),
+          completedBy: userId,
+        },
+        { where: { id: task.id, status: 'à faire' } }
+      );
+      if (affected === 0) {
+        res.status(409).json({
+          message: 'La tâche a déjà été marquée comme terminée par un autre membre.',
+        });
+        return;
+      }
+    } else {
+      // Réouverture — on efface completedAt et completedBy
+      const [affected] = await Task.update(
+        {
+          status: 'à faire',
+          completedAt: undefined,
+          completedBy: undefined,
+        },
+        { where: { id: task.id, status: 'terminée' } }
+      );
+      if (affected === 0) {
+        res.status(409).json({
+          message: 'La tâche a déjà été rouverte par un autre membre.',
+        });
+        return;
+      }
     }
-    await task.update({ status: 'done' });
-    res.status(200).json(task);
+
+    const refreshed = await Task.findByPk(task.id, {
+      attributes: [...TASK_PUBLIC_ATTRIBUTES],
+    });
+    res.status(200).json(refreshed);
   } catch (error) {
     next(error);
   }
 };
 
-export const deleteTask = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+/**
+ * US-17 (suppression) — DELETE /api/tasks/:id
+ * Soft delete (paranoid: true). La ligne reste en base avec deletedAt renseigné.
+ */
+export const deleteTask = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
-    const id = req.params['id'] as string;
-    const task = await Task.findByPk(id);
-    if (!task) {
-      res.status(404).json({ message: 'Tâche introuvable.' });
-      return;
-    }
-    await task.destroy();
+    const task = (req as any).task as Task;
+    await task.destroy(); // soft delete grâce à paranoid: true
     res.status(204).send();
   } catch (error) {
     next(error);

--- a/server/src/middlewares/requireColocationMember.ts
+++ b/server/src/middlewares/requireColocationMember.ts
@@ -1,0 +1,78 @@
+import type { Request, Response, NextFunction } from 'express';
+import Membership from '../models/Membership';
+import Task from '../models/Task';
+
+/**
+ * Vérifie que l'utilisateur authentifié est membre de la colocation visée.
+ *
+ * Source de l'ID de colocation, par ordre de priorité :
+ *   1. req.params.colocationId  (routes /api/colocations/:colocationId/...)
+ *   2. req.params.id            (routes /api/colocations/:id)
+ *   3. Pour les routes /api/tasks/:id — résolution via la Task
+ *
+ * Requiert authenticateToken en amont (lit req.user.id).
+ * Pose req.colocationId et req.role sur la requête pour les controllers en aval.
+ */
+export const requireColocationMember = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const userId = (req as any).user?.id as string | undefined;
+    if (!userId) {
+      res.status(401).json({ message: 'Non authentifié.' });
+      return;
+    }
+
+    // Résolution de l'id de colocation selon la route
+    let colocationId: string | undefined =
+      (req.params['colocationId'] as string | undefined) ??
+      (req.params['id'] as string | undefined);
+
+    // Cas des routes /api/tasks/:id — on récupère colocationId via la Task
+    const isTaskRoute = req.baseUrl.endsWith('/tasks');
+    if (isTaskRoute) {
+      const taskId = req.params['id'] as string | undefined;
+      if (!taskId) {
+        res.status(400).json({ message: 'ID de tâche manquant.' });
+        return;
+      }
+      const task = await Task.findByPk(taskId, {
+        attributes: ['id', 'colocationId'],
+      });
+      if (!task) {
+        res.status(404).json({ message: 'Tâche introuvable.' });
+        return;
+      }
+      colocationId = task.colocationId;
+      // On stocke la tâche pour éviter un second findByPk dans le controller
+      (req as any).task = task;
+    }
+
+    if (!colocationId) {
+      res.status(400).json({ message: 'ID de colocation manquant.' });
+      return;
+    }
+
+    const membership = await Membership.findOne({
+      where: { userId, colocationId },
+      attributes: ['id', 'role', 'colocationId'],
+    });
+
+    if (!membership) {
+      res.status(403).json({
+        message: "Vous n'êtes pas membre de cette colocation.",
+      });
+      return;
+    }
+
+    // Données utiles pour les controllers en aval
+    (req as any).colocationId = colocationId;
+    (req as any).role = membership.role;
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/src/middlewares/requireColocationMember.ts
+++ b/server/src/middlewares/requireColocationMember.ts
@@ -38,9 +38,7 @@ export const requireColocationMember = async (
         res.status(400).json({ message: 'ID de tâche manquant.' });
         return;
       }
-      const task = await Task.findByPk(taskId, {
-        attributes: ['id', 'colocationId'],
-      });
+      const task = await Task.findByPk(taskId)
       if (!task) {
         res.status(404).json({ message: 'Tâche introuvable.' });
         return;

--- a/server/src/models/Task.ts
+++ b/server/src/models/Task.ts
@@ -5,12 +5,14 @@ interface TaskAttributes {
   id: string;
   title: string;
   description?: string;
-  status: 'pending' | 'in_progress' | 'done';
+  status: 'à faire' | 'terminée';
   assignedTo?: string;
   colocationId: string;
   isRecurring: boolean;
   recurringInterval?: string;
   dueDate?: Date;
+  completedAt?: Date;
+  completedBy?: string;
   deletedAt?: Date;
 }
 
@@ -21,12 +23,14 @@ class Task extends Model<TaskAttributes, TaskCreationAttributes>
   public id!: string;
   public title!: string;
   public description?: string;
-  public status!: 'pending' | 'in_progress' | 'done';
+  public status!: 'à faire' | 'terminée';
   public assignedTo?: string;
   public colocationId!: string;
   public isRecurring!: boolean;
   public recurringInterval?: string;
   public dueDate?: Date;
+  public completedAt?: Date;
+  public completedBy?: string;
   public deletedAt?: Date;
 
   public readonly createdAt!: Date;
@@ -50,9 +54,9 @@ Task.init(
       allowNull: true,
     },
     status: {
-      type: DataTypes.ENUM('pending', 'in_progress', 'done'),
+      type: DataTypes.ENUM('à faire', 'terminée'),
       allowNull: false,
-      defaultValue: 'pending',
+      defaultValue: 'à faire',
     },
     assignedTo: {
       type: DataTypes.UUID,
@@ -73,6 +77,14 @@ Task.init(
     },
     dueDate: {
       type: DataTypes.DATE,
+      allowNull: true,
+    },
+    completedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    completedBy: {
+      type: DataTypes.UUID,
       allowNull: true,
     },
   },

--- a/server/src/routes/colocationRoutes.ts
+++ b/server/src/routes/colocationRoutes.ts
@@ -6,6 +6,12 @@ import {
   getMyColocation,
   getColocationById
 } from '../controllers/colocationController';
+import { checkIdParam } from '../middlewares/checkIdParam';
+import { requireColocationMember } from '../middlewares/requireColocationMember';
+import {
+  getColocationTasks,
+  createTaskInColocation,
+} from '../controllers/taskController';
 
 const router = Router();
 
@@ -136,5 +142,107 @@ router.get('/me', authenticateToken, getMyColocation);
  *         description: Erreur serveur
  */
 router.get('/:id', authenticateToken, getColocationById);
+
+/**
+ * @swagger
+ * /api/colocations/{id}/tasks:
+ *   get:
+ *     summary: Liste les tâches de la colocation (avec filtres optionnels)
+ *     tags: [Colocations]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: status
+ *         required: false
+ *         schema:
+ *           type: string
+ *           enum: ['à faire', 'terminée']
+ *         description: Filtrer par statut
+ *       - in: query
+ *         name: assignedTo
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Filtrer par membre assigné
+ *     responses:
+ *       200:
+ *         description: Liste des tâches
+ *       400:
+ *         description: Filtre invalide
+ *       401:
+ *         description: Non authentifié
+ *       403:
+ *         description: Non membre de la colocation
+ *       500:
+ *         description: Erreur serveur
+ */
+router.get(
+  '/:id/tasks',
+  authenticateToken,
+  checkIdParam,
+  requireColocationMember,
+  getColocationTasks
+);
+
+/**
+ * @swagger
+ * /api/colocations/{id}/tasks:
+ *   post:
+ *     summary: Créer une tâche dans la colocation
+ *     tags: [Colocations]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *             properties:
+ *               title:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               dueDate:
+ *                 type: string
+ *                 format: date-time
+ *                 description: Optionnelle, doit être dans le futur si fournie
+ *     responses:
+ *       201:
+ *         description: Tâche créée
+ *       400:
+ *         description: Champs invalides
+ *       401:
+ *         description: Non authentifié
+ *       403:
+ *         description: Non membre de la colocation
+ *       500:
+ *         description: Erreur serveur
+ */
+router.post(
+  '/:id/tasks',
+  authenticateToken,
+  checkIdParam,
+  requireColocationMember,
+  createTaskInColocation
+);
+
 
 export default router;

--- a/server/src/routes/taskRoutes.ts
+++ b/server/src/routes/taskRoutes.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
 import { checkIdParam } from '../middlewares/checkIdParam';
+import { authenticateToken } from '../middlewares/authMiddleware';
+import { requireColocationMember } from '../middlewares/requireColocationMember';
 import {
-  getAllTasks,
-  getTaskById,
-  createTask,
   updateTask,
   assignTask,
   completeTask,
@@ -16,102 +15,17 @@ const router = Router();
  * @swagger
  * tags:
  *   name: Tasks
- *   description: Gestion des tâches ménagères
+ *   description: Gestion des tâches ménagères d'une colocation
  */
-
-/**
- * @swagger
- * /api/tasks:
- *   get:
- *     summary: Récupérer toutes les tâches
- *     tags: [Tasks]
- *     parameters:
- *       - in: query
- *         name: colocationId
- *         schema:
- *           type: string
- *           format: uuid
- *         description: Filtrer par colocation
- *     responses:
- *       200:
- *         description: Liste des tâches
- *       500:
- *         description: Erreur serveur
- */
-router.get('/', getAllTasks);
 
 /**
  * @swagger
  * /api/tasks/{id}:
- *   get:
- *     summary: Récupérer une tâche par son ID
+ *   patch:
+ *     summary: Modifier une tâche (titre, description, date d'échéance)
  *     tags: [Tasks]
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *           format: uuid
- *     responses:
- *       200:
- *         description: La tâche
- *       404:
- *         description: Tâche introuvable
- *       500:
- *         description: Erreur serveur
- */
-router.get('/:id', checkIdParam, getTaskById);
-
-/**
- * @swagger
- * /api/tasks:
- *   post:
- *     summary: Créer une nouvelle tâche
- *     tags: [Tasks]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - title
- *               - colocationId
- *             properties:
- *               title:
- *                 type: string
- *               description:
- *                 type: string
- *               colocationId:
- *                 type: string
- *                 format: uuid
- *               assignedTo:
- *                 type: string
- *                 format: uuid
- *               isRecurring:
- *                 type: boolean
- *               recurringInterval:
- *                 type: string
- *               dueDate:
- *                 type: string
- *                 format: date-time
- *     responses:
- *       201:
- *         description: Tâche créée
- *       400:
- *         description: Champs obligatoires manquants
- *       500:
- *         description: Erreur serveur
- */
-router.post('/', createTask);
-
-/**
- * @swagger
- * /api/tasks/{id}:
- *   put:
- *     summary: Modifier une tâche
- *     tags: [Tasks]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -130,35 +44,41 @@ router.post('/', createTask);
  *                 type: string
  *               description:
  *                 type: string
- *               status:
- *                 type: string
- *                 enum: [pending, in_progress, done]
- *               assignedTo:
- *                 type: string
- *                 format: uuid
- *               isRecurring:
- *                 type: boolean
- *               recurringInterval:
- *                 type: string
+ *                 nullable: true
  *               dueDate:
  *                 type: string
  *                 format: date-time
+ *                 nullable: true
  *     responses:
  *       200:
  *         description: Tâche mise à jour
+ *       400:
+ *         description: Champs invalides
+ *       401:
+ *         description: Non authentifié
+ *       403:
+ *         description: Non membre de la colocation
  *       404:
  *         description: Tâche introuvable
  *       500:
  *         description: Erreur serveur
  */
-router.put('/:id', checkIdParam, updateTask);
+router.patch(
+  '/:id',
+  authenticateToken,
+  checkIdParam,
+  requireColocationMember,
+  updateTask
+);
 
 /**
  * @swagger
  * /api/tasks/{id}/assign:
  *   patch:
- *     summary: Assigner une tâche à un membre
+ *     summary: Assigner ou désassigner une tâche à un membre de la colocation
  *     tags: [Tasks]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -178,24 +98,38 @@ router.put('/:id', checkIdParam, updateTask);
  *               assignedTo:
  *                 type: string
  *                 format: uuid
+ *                 nullable: true
+ *                 description: UUID d'un membre de la colocation, ou null pour désassigner
  *     responses:
  *       200:
- *         description: Tâche assignée
+ *         description: Tâche assignée ou désassignée
  *       400:
- *         description: Champ assignedTo manquant
+ *         description: Champ assignedTo manquant, mal formé, ou utilisateur non membre
+ *       401:
+ *         description: Non authentifié
+ *       403:
+ *         description: Non membre de la colocation
  *       404:
  *         description: Tâche introuvable
  *       500:
  *         description: Erreur serveur
  */
-router.patch('/:id/assign', checkIdParam, assignTask);
+router.patch(
+  '/:id/assign',
+  authenticateToken,
+  checkIdParam,
+  requireColocationMember,
+  assignTask
+);
 
 /**
  * @swagger
  * /api/tasks/{id}/complete:
  *   patch:
- *     summary: Marquer une tâche comme terminée
+ *     summary: Basculer le statut d'une tâche entre 'à faire' et 'terminée'
  *     tags: [Tasks]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -205,20 +139,34 @@ router.patch('/:id/assign', checkIdParam, assignTask);
  *           format: uuid
  *     responses:
  *       200:
- *         description: Tâche marquée comme terminée
+ *         description: Statut basculé
+ *       401:
+ *         description: Non authentifié
+ *       403:
+ *         description: Non membre de la colocation
  *       404:
  *         description: Tâche introuvable
+ *       409:
+ *         description: Conflit — un autre membre a déjà modifié le statut
  *       500:
  *         description: Erreur serveur
  */
-router.patch('/:id/complete', checkIdParam, completeTask);
+router.patch(
+  '/:id/complete',
+  authenticateToken,
+  checkIdParam,
+  requireColocationMember,
+  completeTask
+);
 
 /**
  * @swagger
  * /api/tasks/{id}:
  *   delete:
- *     summary: Supprimer une tâche
+ *     summary: Supprimer une tâche (soft delete)
  *     tags: [Tasks]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -229,11 +177,21 @@ router.patch('/:id/complete', checkIdParam, completeTask);
  *     responses:
  *       204:
  *         description: Tâche supprimée
+ *       401:
+ *         description: Non authentifié
+ *       403:
+ *         description: Non membre de la colocation
  *       404:
  *         description: Tâche introuvable
  *       500:
  *         description: Erreur serveur
  */
-router.delete('/:id', checkIdParam, deleteTask);
+router.delete(
+  '/:id',
+  authenticateToken,
+  checkIdParam,
+  requireColocationMember,
+  deleteTask
+);
 
 export default router;


### PR DESCRIPTION
## Couvert
- US-12 : POST /api/colocations/:id/tasks
- US-14 : PATCH /api/tasks/:id/complete (toggle)
- US-15 : GET /api/colocations/:id/tasks
- US-16 : filtres ?status= et ?assignedTo=
- US-17 : PATCH /api/tasks/:id + DELETE /api/tasks/:id (soft delete)

## Non couvert dans cette PR
- US-13 (assign) : backend implémenté mais test bloqué par US-09 (liste membres)

## Changements structurants
- Nouveau middleware `requireColocationMember` réutilisable pour toutes les routes coloc
- ENUM `Tasks.status` migré de pending/in_progress/done vers 'à faire'/'terminée'
- Ajout colonnes `completedAt` et `completedBy` sur Tasks
- Anciennes routes /api/tasks (GET liste, POST, PUT) supprimées au profit des nouvelles
- Race condition gérée par UPDATE conditionnel dans `completeTask`

## Tests manuels
Tous les endpoints validés via Swagger sur la base prod.

## ⚠️ Migration
La migration `20260521120000` a déjà été appliquée manuellement en prod (incident résolu en cours de session — voir session_8.md). L'entrée est présente dans `SequelizeMeta`, donc le CD ne la rejouera pas.